### PR TITLE
Initial implementation, extracted from sbt-crossproject.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: scala
+
+matrix:
+  include:
+    - scala: "2.12.3"
+      env: SBT_VERSION=1.0.2
+    - scala: "2.10.6"
+      env: SBT_VERSION=0.13.16
+
+script:
+  - sbt "++$TRAVIS_SCALA_VERSION" "^^$SBT_VERSION" publishLocal scripted
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+
+before_cache:
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt -name "*.lock" -print -delete

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,55 @@
+inThisBuild(Seq(
+  organization := "org.portable-scala",
+  version := "1.0.0-SNAPSHOT",
+
+  scalaVersion := "2.12.3",
+  scalacOptions ++= Seq("-deprecation", "-feature", "-encoding", "UTF-8"),
+
+  crossSbtVersions := Seq("1.0.2", "0.13.16"),
+
+  homepage := Some(url("https://github.com/portable-scala/sbt-platform-deps")),
+  licenses += ("BSD 3-Clause",
+      url("https://github.com/portable-scala/sbt-platform-deps/blob/master/LICENSE")),
+  scmInfo := Some(ScmInfo(
+      url("https://github.com/portable-scala/sbt-platform-deps"),
+      "scm:git:git@github.com:portable-scala/sbt-platform-deps.git",
+      Some("scm:git:git@github.com:portable-scala/sbt-platform-deps.git"))),
+))
+
+lazy val `sbt-platform-deps` = project.in(file(".")).
+  settings(
+    sbtPlugin := true,
+
+    scriptedLaunchOpts += "-Dplugin.version=" + version.value,
+    scriptedBufferLog := false,
+
+    // Publish to Bintray, without the sbt-bintray plugin
+    publishTo := {
+      val proj = moduleName.value
+      val ver = version.value
+      if (isSnapshot.value) {
+        None // Bintray does not support snapshots
+      } else {
+        val url = new java.net.URL(
+            s"https://api.bintray.com/content/portable-scala/sbt-plugins/$proj/$ver")
+        val patterns = Resolver.ivyStylePatterns
+        Some(Resolver.url("bintray", url)(patterns))
+      }
+    },
+
+    pomExtra := (
+      <developers>
+        <developer>
+          <id>sjrd</id>
+          <name>Sébastien Doeraene</name>
+          <url>https://github.com/sjrd/</url>
+        </developer>
+        <developer>
+          <id>densh</id>
+          <name>Denys Shabalin</name>
+          <url>https://github.com/densh/</url>
+        </developer>
+      </developers>
+    ),
+    pomIncludeRepository := { _ => false },
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/org/portablescala/sbtplatformdeps/PlatformDepsBuilders.scala
+++ b/src/main/scala/org/portablescala/sbtplatformdeps/PlatformDepsBuilders.scala
@@ -1,0 +1,52 @@
+package org.portablescala.sbtplatformdeps
+
+import sbt._
+
+import scala.language.experimental.macros
+import scala.reflect.macros.Context
+
+final class PlatformDepsGroupID private[sbtplatformdeps] (
+    private val groupID: String) {
+  def %%%(artifactID: String): PlatformDepsGroupArtifactID =
+    macro PlatformDepsGroupID.cross_binary_impl
+}
+
+object PlatformDepsGroupID {
+  /** Internal, used by the macro implementing [[PlatformDepsGroupID.%%%]].
+   *
+   *  Use [[PlatformDepsPlugin.autoImport.platformDepsCrossVersion]] instead.
+   */
+  val platformDepsCrossVersion: SettingKey[CrossVersion] =
+    PlatformDepsPlugin.autoImport.platformDepsCrossVersion
+
+  /** Internal, used by the macro implementing [[PlatformDepsGroupID.%%%]].
+   *
+   *  Use:
+   *  {{{
+   *  ("a" % artifactID % revision).cross(cross)
+   *  }}}
+   *  instead.
+   */
+  def withCross(groupID: PlatformDepsGroupID, artifactID: String,
+      cross: CrossVersion): PlatformDepsGroupArtifactID = {
+    require(artifactID.nonEmpty, "Artifact ID must not be empty")
+    new PlatformDepsGroupArtifactID(groupID.groupID, artifactID, cross)
+  }
+
+  def cross_binary_impl(c: Context { type PrefixType = PlatformDepsGroupID })(
+      artifactID: c.Expr[String]): c.Expr[PlatformDepsGroupArtifactID] = {
+    import c.universe._
+    reify {
+      PlatformDepsGroupID.withCross(c.prefix.splice, artifactID.splice,
+          PlatformDepsGroupID.platformDepsCrossVersion.value)
+    }
+  }
+}
+
+final class PlatformDepsGroupArtifactID private[sbtplatformdeps] (
+    groupID: String, artifactID: String, crossVersion: CrossVersion) {
+  def %(revision: String): ModuleID = {
+    require(revision.nonEmpty, "Revision must not be empty")
+    ModuleID(groupID, artifactID, revision).cross(crossVersion)
+  }
+}

--- a/src/main/scala/org/portablescala/sbtplatformdeps/PlatformDepsPlugin.scala
+++ b/src/main/scala/org/portablescala/sbtplatformdeps/PlatformDepsPlugin.scala
@@ -1,0 +1,37 @@
+package org.portablescala.sbtplatformdeps
+
+import scala.language.implicitConversions
+
+import sbt._
+import sbt.Keys._
+
+object PlatformDepsPlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+    /** `CrossVersion` used for `%%%` dependencies (read only in most cases).
+     *
+     *  Usually, you should never set `platformDepsCrossVersion` yourself. It
+     *  is the responsibility of the sbt plugin providing a particular platform
+     *  to do so (e.g., `ScalaJSPlugin` or `ScalaNativePlugin`).
+     *
+     *  This setting is read by `%%%`.
+     */
+    val platformDepsCrossVersion: SettingKey[CrossVersion] = {
+      SettingKey[CrossVersion]("platformDepsCrossVersion",
+          "CrossVersion used for %%% dependencies", sbt.KeyRanks.DSetting)
+    }
+
+    implicit def toPlatformDepsGroupID(groupID: String): PlatformDepsGroupID = {
+      require(groupID.nonEmpty, "Group ID may not be empty")
+      new PlatformDepsGroupID(groupID)
+    }
+  }
+
+  import autoImport._
+
+  override def globalSettings: Seq[Setting[_]] = Def.settings(
+      // By default, %%% uses JVM dependencies
+      platformDepsCrossVersion := CrossVersion.binary
+  )
+}

--- a/src/sbt-test/sbt-platform-deps/simple/build.sbt
+++ b/src/sbt-test/sbt-platform-deps/simple/build.sbt
@@ -1,0 +1,51 @@
+val testDependency = settingKey[ModuleID]("Test ModuleID that we test")
+val check = taskKey[Unit]("Check that the testDependency was correctly constructed")
+
+val TestOrg = "org.example"
+val TestArtifact = "foobar"
+val TestVersion = "1.2.3"
+
+def assertEquals(expected: Any, actual: Any): Unit =
+  assert(actual == expected, s"Expected: $expected ; actual: $actual")
+
+inThisBuild(Seq(
+  version := "0.1",
+  scalaVersion := "2.12.3"
+))
+
+lazy val `jvm-by-default` = project.in(file("jvm-by-default")).
+  settings(
+    testDependency := TestOrg %%% TestArtifact % TestVersion,
+
+    check := {
+      val moduleID = testDependency.value
+      assertEquals(TestOrg, moduleID.organization)
+      assertEquals(TestArtifact, moduleID.name)
+      assertEquals(TestVersion, moduleID.revision)
+
+      // In sbt 0.13, CrossVersion's do not have a meaningful ==
+      if (sbtVersion.value.startsWith("0.13."))
+        assertEquals("Binary", moduleID.crossVersion.toString)
+      else
+        assertEquals(CrossVersion.binary, moduleID.crossVersion)
+    }
+  )
+
+lazy val `custom-cross-version` = project.in(file("custom-cross-version")).
+  settings(
+    platformDepsCrossVersion := CrossVersion.full,
+    testDependency := TestOrg %%% TestArtifact % TestVersion,
+
+    check := {
+      val moduleID = testDependency.value
+      assertEquals(TestOrg, moduleID.organization)
+      assertEquals(TestArtifact, moduleID.name)
+      assertEquals(TestVersion, moduleID.revision)
+
+      // In sbt 0.13, CrossVersion's do not have a meaningful ==
+      if (sbtVersion.value.startsWith("0.13."))
+        assertEquals("Full", moduleID.crossVersion.toString)
+      else
+        assertEquals(CrossVersion.full, moduleID.crossVersion)
+    }
+  )

--- a/src/sbt-test/sbt-platform-deps/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-platform-deps/simple/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % System.getProperty("plugin.version"))

--- a/src/sbt-test/sbt-platform-deps/simple/test
+++ b/src/sbt-test/sbt-platform-deps/simple/test
@@ -1,0 +1,2 @@
+> jvm-by-default/check
+> custom-cross-version/check


### PR DESCRIPTION
In sbt-crossproject, `%%%` based its decisions on the value of `crossPlatform`. Obviously, it cannot do so here, since `crossPlatform` is a concept of sbt-crossproject. Instead, we have a dedicated setting `platformDepsCrossVersion`, which directly holds the `CrossVersion` to use in generated `ModuleID`s.

sbt plugins for platforms, such as sbt-scalajs and sbt-scala-native, only need to set this setting to an appropriate `CrossVersion` for `%%%` to work as expected.