### PR TITLE
FF ONLY Version 1.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ It should not be directly used.
 
 ## Latest release
 
-The latest release is 1.0.0-M2.
+The latest release is 1.0.0.
 It can be depended on with
 
 ```scala
-addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0-M2")
+addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 ```
 
 As a user, you should typically never depend on sbt-platform-deps.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(Seq(
   organization := "org.portable-scala",
-  version := "1.0.0-SNAPSHOT",
+  version := "1.0.0",
 
   scalaVersion := "2.12.3",
   scalacOptions ++= Seq("-deprecation", "-feature", "-encoding", "UTF-8"),


### PR DESCRIPTION
Now that there is a version of scala-native out there based on sbt-platform-deps 1.0.0-M2, and there haven't been complaints about it, I think we have good enough confidence to publish 1.0.0 final.

After that, we can never break backwards binary compatibility.