### PR TITLE
Upgrade to sbt 1.9.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ inThisBuild(Seq(
   scalacOptions ++= Seq("-deprecation", "-feature", "-encoding", "UTF-8"),
 
   crossSbtVersions := Seq("1.0.2", "0.13.16"),
+  sbtVersion in pluginCrossBuild := "1.0.2",
 
   homepage := Some(url("https://github.com/portable-scala/sbt-platform-deps")),
   licenses += ("BSD 3-Clause",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.9.0


### PR DESCRIPTION
sbt 1.9.0 contains the new sbt plugin publishing mechanism. It dual-publishes sbt plugins with Ivy-style paths (invalid in Maven, although it works out when released from sbt) and valid Maven paths.

See https://github.com/sbt/sbt/issues/3410 and
https://github.com/sbt/sbt/pull/7096.